### PR TITLE
Add ability `sync` for Storages that are eventually consistent

### DIFF
--- a/CBStore/Keys/StoreKey.swift
+++ b/CBStore/Keys/StoreKey.swift
@@ -15,17 +15,22 @@ public class StoreKey<T>: StoreKeys {
     /// Stored value type
     let valueType: T.Type
 
+    /// Determine whether to immediately sync UserDefaults to disk. Default is false
+    let syncNow: Bool
+
     /// Constructor to create a custom store key
     ///
     /// - parameter prefixOrName: Key name or key prefix if udid is specified
     /// - parameter uuid:         Optional unique identifier
     /// - parameter kind:         Type of value to store.
+    /// - parameter syncNow:      Determine whether to persist to disk immediately.
     ///
     /// - returns: A new `StoreKey` instance
     init(
         _ prefixOrName: String,
         uuid: String? = nil,
-        kind: StoreKind = .userDefaults
+        kind: StoreKind = .userDefaults,
+        syncNow: Bool = false
     ) {
         let valueType = T.self
         let pieces = [kind.rawValue, prefixOrName, uuid, "\(type(of: valueType))"]
@@ -34,6 +39,7 @@ public class StoreKey<T>: StoreKeys {
         self.valueType = valueType
         self.uuid = uuid
         self.kind = kind
+        self.syncNow = syncNow
     }
 }
 

--- a/CBStore/Keys/UserDefaultsStoreKey.swift
+++ b/CBStore/Keys/UserDefaultsStoreKey.swift
@@ -9,7 +9,7 @@ public class UserDefaultsStoreKey<T>: StoreKey<T> {
     /// - parameter uuid:         Optional unique identifier
     ///
     /// - returns: A new `StoreKey` instance
-    public init(_ prefixOrName: String, uuid: String? = nil) {
-        super.init(prefixOrName, uuid: uuid, kind: .userDefaults)
+    public init(_ prefixOrName: String, uuid: String? = nil, syncNow: Bool = false) {
+        super.init(prefixOrName, uuid: uuid, kind: .userDefaults, syncNow: syncNow)
     }
 }

--- a/CBStore/Module/Store.swift
+++ b/CBStore/Module/Store.swift
@@ -60,6 +60,10 @@ public final class Store: StoreProtocol {
             case .cloud:
                 cloudStorage.set(key.name, value: value?.toStoreValue())
             }
+
+            if key.syncNow {
+                storage.sync()
+            }
         }
 
         if hasObserver && isDestroyed {

--- a/CBStore/PersistentStorage/CloudStorage.swift
+++ b/CBStore/PersistentStorage/CloudStorage.swift
@@ -16,6 +16,10 @@ struct CloudStorage: Storage {
         return NSUbiquitousKeyValueStore.default.object(forKey: key)
     }
 
+    func sync() {
+        _ = NSUbiquitousKeyValueStore.default.synchronize()
+    }
+
     func destroy() {
         let keys = NSUbiquitousKeyValueStore.default.dictionaryRepresentation.keys
 

--- a/CBStore/PersistentStorage/KeychainStorage.swift
+++ b/CBStore/PersistentStorage/KeychainStorage.swift
@@ -53,6 +53,8 @@ struct KeychainStorage: Storage {
         SecItemDelete([kSecClass as String: kSecClassGenericPassword] as CFDictionary)
     }
 
+    func sync() {}
+
     // MARK: - Private helpers
 
     private func queryDictionary(key: String) -> [String: AnyObject] {

--- a/CBStore/PersistentStorage/MemoryStorage.swift
+++ b/CBStore/PersistentStorage/MemoryStorage.swift
@@ -26,4 +26,6 @@ final class MemoryStorage: Storage {
     func destroy() {
         cache.removeAll()
     }
+
+    func sync() {}
 }

--- a/CBStore/PersistentStorage/UserDefaultsStorage.swift
+++ b/CBStore/PersistentStorage/UserDefaultsStorage.swift
@@ -21,4 +21,8 @@ struct UserDefaultsStorage: Storage {
             UserDefaults.standard.removePersistentDomain(forName: domain)
         }
     }
+
+    func sync() {
+        CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
+    }
 }

--- a/CBStore/Protocols/Storage.swift
+++ b/CBStore/Protocols/Storage.swift
@@ -19,4 +19,7 @@ protocol Storage {
 
     /// Delete all keys in storage
     func destroy()
+
+    /// If supported, persist changes to disk immediat. Otherwise, it's a noop
+    func sync()
 }


### PR DESCRIPTION
There are a few StoreKeys on Wallet app where storing a value in UserDefaults needs to be an atomically persisted operation. Generally it's not needed but for keys `.activeUserId`, the side effect of  not immediately storing the key can be disastrous. 

This patch allows us to specify `syncNow=true` on specific `StoreKeys` to make sure the appropriate storage sync mechanism is fired.