### PR TITLE
Fix observer and memory storage deadlock

### DIFF
--- a/CBStore/Module/Store.swift
+++ b/CBStore/Module/Store.swift
@@ -213,13 +213,14 @@ public final class Store: StoreProtocol {
 
         // If we can't find an observer, enter serial mode and check or create new observer
         var newObserver: BehaviorSubject<T?>!
+        let value = get(key)
+
         changeObserverAccessQueue.sync(flags: .barrier) {
             if let observer = self.changeObservers[key.name] as? BehaviorSubject<T?> {
                 newObserver = observer
                 return
             }
 
-            let value = get(key)
             let observer = BehaviorSubject<T?>(value: value)
             changeObservers[key.name] = observer
             newObserver = observer

--- a/CBStore/PersistentStorage/MemoryStorage.swift
+++ b/CBStore/PersistentStorage/MemoryStorage.swift
@@ -4,11 +4,11 @@ import Foundation
 
 /// Storage for user defaults
 final class MemoryStorage: Storage {
-    private let accessQueue = DispatchQueue(label: "memoryStorageQueue", qos: .userInitiated, attributes: .concurrent)
+    private let accessQueue = DispatchQueue(label: "CBStore.MemoryStorage.accessQueue")
     private var cache = [String: Any]()
 
     func set(_ key: String, value: Any?) {
-        accessQueue.async(flags: .barrier) {
+        accessQueue.sync {
             self.cache[key] = value
         }
     }


### PR DESCRIPTION
A concurrency bug was introduced in https://github.com/CoinbaseWallet/CBStore/commit/240297801fd03798969983290ee462e05b292ca0 that's causing the app to deadlock. The deadlock was due to couple issues:
1. In `Store.swift`, two dispatch queues calling into each other with one having `sync(flags: .barrier)` (blocking) and the other calling `sync`.
2. In `MemoryStorage`, there was an unnecessary `sync(flags: .barrier)` that could deadlock if escaped. Switched this to a serial queue