### PR TITLE
Android: Fix removeAll kinds parameters + fix unit tests

### DIFF
--- a/android/store/src/main/java/com/coinbase/wallet/store/Store.kt
+++ b/android/store/src/main/java/com/coinbase/wallet/store/Store.kt
@@ -80,9 +80,6 @@ class Store(context: Context) : StoreInterface {
 
         changeObservers.values.forEach {
             val observer = it as? BehaviorSubject<Optional<Any>>
-
-            if (isDestroyed) return
-
             observer?.onNext(null.toOptional())
         }
     }

--- a/android/store/src/main/java/com/coinbase/wallet/store/Store.kt
+++ b/android/store/src/main/java/com/coinbase/wallet/store/Store.kt
@@ -70,13 +70,19 @@ class Store(context: Context) : StoreInterface {
         deleteAllEntries(kinds = StoreKind.values())
     }
 
-    override fun removeAll(kinds: Array<StoreKind>) = accessLock.write {
-        if (isDestroyed) return
+    @Suppress("UNCHECKED_CAST")
+    override fun removeAll(kinds: Array<StoreKind>) {
+        accessLock.write {
+            if (isDestroyed) return
 
-        deleteAllEntries(kinds = StoreKind.values())
+            deleteAllEntries(kinds)
+        }
 
         changeObservers.values.forEach {
             val observer = it as? BehaviorSubject<Optional<Any>>
+
+            if (isDestroyed) return
+
             observer?.onNext(null.toOptional())
         }
     }
@@ -124,9 +130,9 @@ class Store(context: Context) : StoreInterface {
             val observer = BehaviorSubject.create<Optional<T>>()
             changeObservers[key.name] = observer
             newObserver = observer
-
-            observer.onNext(value.toOptional())
         }
+
+        newObserver?.onNext(value.toOptional())
 
         return newObserver ?: throw StoreException.UnableToCreateObserver()
     }


### PR DESCRIPTION
This patch fixes the following:

1. removeAll wasn't passing the `kinds` parameter correctly
2. Unit tests were failing 