### PR TITLE
Fix compile issue introduced with array Codable extension

### DIFF
--- a/ios/CBStore/Protocols/Storable.swift
+++ b/ios/CBStore/Protocols/Storable.swift
@@ -63,5 +63,3 @@ public extension Storable where Self: Codable {
         return try? decoder.decode(self, from: data)
     }
 }
-
-extension Array: Storable where Element: Codable { }

--- a/ios/StoresTests/StoreTests.swift
+++ b/ios/StoresTests/StoreTests.swift
@@ -59,17 +59,6 @@ class StoreTests: XCTestCase {
 
         XCTAssertEqual(obj, stores.get(.codableKey))
     }
-    
-    func testUserDefaultArrayBasedKey() {
-        let expected = [
-            ExampleStruct(name: "User 1", age: 11),
-            ExampleStruct(name: "User 2", age: 22)
-        ]
-
-        stores.set(.structArrayKey, value: expected)
-        
-        XCTAssertEqual(expected, stores.get(.arrayBasedKey))
-    }
 
     // MARK: - Cloud tests
 


### PR DESCRIPTION
With the latest Xcode (11.4), it seems like the recently introduced extension for array codable is not compiling on master. This fixes the issue